### PR TITLE
Fix import paths of go tools for Go 1.4

### DIFF
--- a/haxe/base.go
+++ b/haxe/base.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"strings"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 	"github.com/tardisgo/tardisgo/pogo"
 )
 

--- a/haxe/builtin.go
+++ b/haxe/builtin.go
@@ -4,7 +4,7 @@
 
 package haxe
 
-import "code.google.com/p/go.tools/go/ssa"
+import "golang.org/x/tools/go/ssa"
 
 func (l langType) append(args []ssa.Value, errorInfo string) string {
 	source := l.IndirectValue(args[1], errorInfo)

--- a/haxe/goclass.go
+++ b/haxe/goclass.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"unsafe"
 
-	"code.google.com/p/go.tools/go/exact"
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/exact"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 	"github.com/tardisgo/tardisgo/pogo"
 )
 

--- a/haxe/hx.go
+++ b/haxe/hx.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/go.tools/go/ssa"
+	"golang.org/x/tools/go/ssa"
 )
 
 func (l langType) hxPseudoFuncs(fnToCall string, args []ssa.Value, errorInfo string) string {

--- a/haxe/ops.go
+++ b/haxe/ops.go
@@ -7,8 +7,8 @@ package haxe
 import (
 	"fmt"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 	"github.com/tardisgo/tardisgo/pogo"
 )
 

--- a/haxe/overload.go
+++ b/haxe/overload.go
@@ -7,7 +7,7 @@ package haxe
 import (
 	"go/ast"
 
-	"code.google.com/p/go.tools/go/ssa"
+	"golang.org/x/tools/go/ssa"
 	//"fmt"
 )
 

--- a/haxe/peepholeopt.go
+++ b/haxe/peepholeopt.go
@@ -7,8 +7,8 @@ package haxe
 import (
 	"fmt"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 )
 
 type phiEntry struct{ reg, val string }

--- a/haxe/types.go
+++ b/haxe/types.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"strings"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 	"github.com/tardisgo/tardisgo/pogo"
 )
 

--- a/pogo/begin.go
+++ b/pogo/begin.go
@@ -9,8 +9,8 @@ import (
 	"go/token"
 	"strconv"
 
-	"code.google.com/p/go.tools/go/exact"
-	"code.google.com/p/go.tools/go/ssa"
+	"golang.org/x/tools/go/exact"
+	"golang.org/x/tools/go/ssa"
 
 	// TARDIS Go included runtime libraries, so that they get installed and the SSA code can go and load their binary form
 	_ "github.com/tardisgo/tardisgo/golibruntime"

--- a/pogo/constants.go
+++ b/pogo/constants.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"go/token"
 
-	"code.google.com/p/go.tools/go/exact"
-	"code.google.com/p/go.tools/go/ssa"
+	"golang.org/x/tools/go/exact"
+	"golang.org/x/tools/go/ssa"
 )
 
 // emit the constant declarations

--- a/pogo/function.go
+++ b/pogo/function.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"unicode"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 
 	"github.com/tardisgo/tardisgo/tgossa"
 )

--- a/pogo/globals.go
+++ b/pogo/globals.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"unicode"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 )
 
 /* THIS SECTION ONLY REQUIRED IF GLOBALS ARE ADDRESSABLE USING OFFSETS RATTHER THAN PSEUDO-POINTERS

--- a/pogo/instructions.go
+++ b/pogo/instructions.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 )
 
 // RegisterName returns the name of an ssa.Value, a utility function in case it needs to be altered.

--- a/pogo/language.go
+++ b/pogo/language.go
@@ -10,8 +10,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 )
 
 // The Language interface enables multiple target languages for TARDIS Go.

--- a/pogo/peephole.go
+++ b/pogo/peephole.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"go/token"
 
-	"code.google.com/p/go.tools/go/ssa"
+	"golang.org/x/tools/go/ssa"
 )
 
 // peephole optimizes and emits short sequences of instructions that do not contain control flow

--- a/pogo/pointers.go
+++ b/pogo/pointers.go
@@ -7,8 +7,8 @@ package pogo
 import (
 	"fmt"
 
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 )
 
 // This function in case special handing is required for pointers.

--- a/pogo/types.go
+++ b/pogo/types.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"code.google.com/p/go.tools/go/types"
-	"code.google.com/p/go.tools/go/types/typeutil"
+	"golang.org/x/tools/go/types"
+	"golang.org/x/tools/go/types/typeutil"
 )
 
 // IsValidInPogo exists to screen out any types that the system does not handle correctly.

--- a/tardisgo.go
+++ b/tardisgo.go
@@ -22,10 +22,10 @@ import (
 	"runtime"
 	"runtime/pprof"
 
-	"code.google.com/p/go.tools/go/loader"
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/ssa/interp"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/interp"
+	"golang.org/x/tools/go/types"
 
 	// TARDIS Go additions
 	"os/exec"

--- a/tgossa/visit.go
+++ b/tgossa/visit.go
@@ -8,8 +8,8 @@
 package tgossa // was ssautil
 
 import (
-	"code.google.com/p/go.tools/go/ssa"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types"
 )
 
 // TARDISGO VERSION MODIFIED FROM


### PR DESCRIPTION
Go 1.4 requires to change the import path code.google.com/p/go.tools/\* to golang.org/x/tools/*. This should also work on Go 1.3.

See also: http://tip.golang.org/doc/go1.4#subrepo
